### PR TITLE
Assistant checkpoint: Add tech stack section with icons and descriptions

### DIFF
--- a/script.js
+++ b/script.js
@@ -81,6 +81,23 @@ async function loadResume() {
         });
         resumeDiv.appendChild(jobs);
 
+        // Tech Stack
+        const techStack = document.createElement("div");
+        techStack.classList.add("section");
+        techStack.innerHTML = `
+            <h2>Technologies</h2>
+            <div class="tech-grid">
+                ${Object.entries(data.TechIcons.techstack).map(([key, tech]) => `
+                    <div class="tech-item">
+                        <img src="${tech.bgimg}" alt="${tech.title}" class="tech-icon">
+                        <h4>${tech.title}</h4>
+                        <p>${tech.desc}</p>
+                    </div>
+                `).join('')}
+            </div>
+        `;
+        resumeDiv.appendChild(techStack);
+
         // Picture Gallery
         // const gallery = document.createElement("div");
         // gallery.classList.add("section");

--- a/styles.css
+++ b/styles.css
@@ -103,6 +103,35 @@ body {
     text-align: left;
 }
 
+.tech-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    padding: 1rem 0;
+}
+
+.tech-item {
+    padding: 1rem;
+    border: 1px solid #eee;
+    border-radius: 8px;
+    text-align: center;
+}
+
+.tech-icon {
+    width: 64px;
+    height: 64px;
+    margin-bottom: 1rem;
+}
+
+.tech-item h4 {
+    margin-bottom: 0.5rem;
+}
+
+.tech-item p {
+    font-size: 0.9rem;
+    color: #666;
+}
+
 @media print {
     body {
         background-color: white;


### PR DESCRIPTION
Assistant generated file changes:
- script.js: Add tech stack section
- styles.css: Add tech stack styles

---

User prompt:

the resume.json has an object called techstack. Can you, under workexperience but above the links, make a section that uses the bgimg images of each object in tech stack and displays the desc description for each title?